### PR TITLE
ci: add dependabot and PR title check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
 ## Summary
 What changed and why?
+PR title must start with: docs:, chore:, ci:, feat:, fix:, refactor:, test:, perf:, security:
 
 ## Scope (folders touched)
 - [ ] apps/web

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -1,0 +1,23 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  title-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "PR title: $PR_TITLE"
+          if echo "$PR_TITLE" | grep -Eq '^(docs|chore|ci|feat|fix|refactor|test|perf|security):'; then
+            exit 0
+          fi
+          echo "❌ PR title must start with one of: docs:, chore:, ci:, feat:, fix:, refactor:, test:, perf:, security:"
+          exit 1


### PR DESCRIPTION
## Summary
What changed and why?

## Scope (folders touched)
- [ ] apps/web
- [ ] apps/mobile
- [ ] services/api
- [ ] packages/shared
- [ ] infra
- [ ] docs
- [ ] scripts
- [ ] .github

## Risk & mitigations
What could break? How did you reduce risk?

## Tests
- Ran: (list commands)
- Added/updated tests: (what/where)

## Rollback plan
How to revert safely?

## Notes
Screenshots/logs/migration notes if relevant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces automated dependency updates and enforces conventional PR titles.
> 
> - Adds `.github/dependabot.yml` to enable weekly `npm` and `pip` updates with a limit of 5 open PRs each
> - Creates `.github/workflows/pr_title.yml` to fail PRs whose titles don’t start with `docs|chore|ci|feat|fix|refactor|test|perf|security:`
> - Updates `.github/pull_request_template.md` to document the required PR title prefixes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25a9045c91746bb09d51e5d59af1a98e4c266ccb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->