### PR TITLE
docs: add ADRs for boundaries and cross-scope protocol

### DIFF
--- a/docs/adr/ADR-0001-repo-boundaries-ownership.md
+++ b/docs/adr/ADR-0001-repo-boundaries-ownership.md
@@ -1,0 +1,37 @@
+# ADR-0001: Repo Boundaries & Ownership
+
+## Status
+Accepted
+
+## Context
+We need clear, enforceable ownership boundaries so multiple agents can work in parallel without unintended cross-scope edits.
+
+## Decision
+Adopt a folder ownership model with explicit scopes:
+- apps/web
+- apps/mobile
+- services/api
+- packages/shared
+- infra
+- docs
+- .github
+- scripts
+
+Agents may only modify files within their assigned scope. Cross-scope changes are not allowed in a single PR and must follow the cross-scope protocol.
+
+CI enforces scope boundaries at a high level by validating file paths touched in a PR against the declared scope for that change.
+
+## Alternatives considered
+- No explicit scope ownership, relying on code review.
+- Broad ownership for all agents.
+
+## Consequences
+- Slower cross-cutting changes due to split PRs.
+- Safer parallelism and lower risk of accidental scope violations.
+
+## Rollout plan
+- Document scopes in this ADR and the ADR README.
+- Communicate scope rules in agent instructions.
+
+## Rollback plan
+- Remove CI scope checks and revert to review-only enforcement.

--- a/docs/adr/ADR-0002-cross-scope-change-protocol.md
+++ b/docs/adr/ADR-0002-cross-scope-change-protocol.md
@@ -1,0 +1,39 @@
+# ADR-0002: Cross-Scope Change Protocol (Contracts + Compatibility)
+
+## Status
+Accepted
+
+## Context
+Changes that touch multiple scopes can break consumers or create conflicting edits. We need a standard protocol for contracts and compatibility.
+
+## Decision
+A change is "cross-scope" when it modifies files in more than one ownership scope or requires consumers in another scope to adjust behavior.
+
+Required process:
+- Split PRs by scope.
+- Keep backward compatibility for all contracts.
+- Use a staged rollout sequence: shared contracts first, then consumer updates.
+- Use semantic versioning or contract versioning for shared packages and APIs, even if initially minimal (e.g., patch/minor for backward-compatible changes).
+
+An ADR is mandatory for: auth/session handling, payments/billing, DB schema changes impacting production data, public API breaking changes, security middleware/routing core, and secrets/keys/encryption logic.
+
+Rollback patterns:
+- Revert consumers to previous contract version.
+- Keep old endpoints/types until all consumers migrate.
+- Feature flag new behavior where practical.
+
+## Alternatives considered
+- Allow cross-scope edits in a single PR.
+- Rely on ad-hoc coordination without versioning.
+
+## Consequences
+- More coordination overhead.
+- Reduced integration risk and clearer compatibility guarantees.
+
+## Rollout plan
+- Document protocol in this ADR and the ADR README.
+- Align future shared contract changes to staged rollouts.
+
+## Rollback plan
+- Revert staged PRs in reverse order.
+- Restore previous contract version in packages/shared or APIs.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,19 @@
+# Architecture Decision Records (ADRs)
+
+## How to write ADRs
+- Keep them short and specific.
+- Use the template in `docs/adr/0000-template.md`.
+- Capture context, decision, consequences, and rollout/rollback plans.
+
+## Naming rules
+- Use `ADR-XXXX-short-title.md` with a zero-padded number.
+- Increment numbers sequentially.
+
+## When ADRs are required
+- Auth/session handling
+- Payments/billing
+- DB schema changes impacting production data
+- Public API breaking changes
+- Security middleware/routing core
+- Secrets/keys/encryption logic
+- Cross-scope changes affecting contracts or compatibility


### PR DESCRIPTION
## Summary
What changed and why?
PR title must start with: docs:, chore:, ci:, feat:, fix:, refactor:, test:, perf:, security:

## Scope (folders touched)
- [ ] apps/web
- [ ] apps/mobile
- [ ] services/api
- [ ] packages/shared
- [ ] infra
- [ ] docs
- [ ] scripts
- [ ] .github

## Risk & mitigations
What could break? How did you reduce risk?

## Tests
- Ran: (list commands)
- Added/updated tests: (what/where)

## Rollback plan
How to revert safely?

## Notes
Screenshots/logs/migration notes if relevant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces governance docs to formalize scope ownership and cross-scope changes.
> 
> - Adds `docs/adr/ADR-0001-repo-boundaries-ownership.md` defining folder-based ownership scopes (`apps/*`, `services/api`, `packages/shared`, `infra`, `docs`, `.github`, `scripts`) and high-level CI enforcement
> - Adds `docs/adr/ADR-0002-cross-scope-change-protocol.md` detailing split-PR workflow, backward-compatible staged rollouts, versioning of shared contracts/APIs, mandatory ADR areas, and rollback patterns
> - Adds `docs/adr/README.md` with ADR writing/naming rules and when ADRs are required
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fbf80136950b17d22694f9a2ec1c0505afdf322. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->