### PR TITLE
docs: add security baseline and review checklist

### DIFF
--- a/docs/security/PR_SECURITY_CHECKLIST.md
+++ b/docs/security/PR_SECURITY_CHECKLIST.md
@@ -1,0 +1,9 @@
+# PR Security Checklist
+
+- No secrets, tokens, or credentials added.
+- Auth/session changes reviewed for cookie flags, CSRF, and MFA requirements.
+- Access control enforced on new routes and APIs.
+- Inputs validated and outputs encoded where needed.
+- Logging avoids PII/secrets and includes redaction where relevant.
+- Dependencies pinned and major upgrades approved.
+- New security-sensitive behavior has tests or documented manual checks.

--- a/docs/security/SECURITY_BASELINE.md
+++ b/docs/security/SECURITY_BASELINE.md
@@ -1,0 +1,39 @@
+# Security Baseline
+
+## Secrets policy
+- Never commit secrets, tokens, private keys, or credentials to the repo.
+- Use environment variables for all secrets; keep `.env` files out of git.
+- Provide `.env.example` with placeholder values only.
+- Rotate secrets on employee offboarding, breach suspicion, or vendor compromise.
+- Scope secrets to the minimum required privileges and environments.
+
+## Auth/session checklist
+- Use secure, HTTP-only cookies for session identifiers.
+- Set `Secure`, `HttpOnly`, and `SameSite=Lax` (or `Strict` where safe) on auth cookies.
+- Store tokens in server-side sessions or secure cookies; avoid localStorage for auth.
+- Enforce CSRF protection on state-changing routes when using cookies.
+- Require MFA for admin and privileged access paths.
+- Use short-lived access tokens with refresh rotation when applicable.
+
+## Logging rules
+- Do not log secrets, tokens, passwords, or full credentials.
+- Do not log PII unless necessary; use redaction.
+- Redaction examples:
+  - Replace `Authorization: Bearer <token>` with `Authorization: Bearer [REDACTED]`.
+  - Mask emails as `user@example.com` -> `u***@example.com`.
+  - Truncate IDs to last 4 characters when possible.
+- Log only what is needed for debugging and audits.
+
+## Dependency policy
+- Pin direct dependencies to exact versions where possible.
+- Review and update dependencies on a fixed cadence (at least monthly).
+- Security patches may be fast-tracked outside the cadence.
+- Major upgrades require approval from the owning agent and a security review.
+- Track licenses for new dependencies and ensure compatibility.
+
+## Minimal incident response steps
+- Revoke and rotate affected keys or tokens immediately.
+- Identify blast radius: affected services, data, and users.
+- Remove leaked secrets from all logs and artifacts if possible.
+- Audit recent access for suspicious activity and preserve evidence.
+- Notify stakeholders and update runbooks with lessons learned.


### PR DESCRIPTION
## Summary
What changed and why?
PR title must start with: docs:, chore:, ci:, feat:, fix:, refactor:, test:, perf:, security:

## Scope (folders touched)
- [ ] apps/web
- [ ] apps/mobile
- [ ] services/api
- [ ] packages/shared
- [ ] infra
- [ ] docs
- [ ] scripts
- [ ] .github

## Risk & mitigations
What could break? How did you reduce risk?

## Tests
- Ran: (list commands)
- Added/updated tests: (what/where)

## Rollback plan
How to revert safely?

## Notes
Screenshots/logs/migration notes if relevant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces security documentation to standardize practices and PR reviews.
> 
> - Adds `docs/security/SECURITY_BASELINE.md` outlining secrets policy, auth/session requirements (cookie flags, CSRF, MFA), logging redaction rules, dependency pinning/update policy, and minimal incident response steps
> - Adds `docs/security/PR_SECURITY_CHECKLIST.md` for reviewers to verify no secrets, correct auth/session controls, access control on new routes/APIs, input validation/output encoding, safe logging, dependency pinning/approvals, and tests/manual checks for security-sensitive changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dae72f8bf4af42c32172b24096bb6423656ba00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->